### PR TITLE
fix: metadata url for comparison page

### DIFF
--- a/app/compare/appflowy-vs-affine/page.tsx
+++ b/app/compare/appflowy-vs-affine/page.tsx
@@ -91,7 +91,7 @@ export async function generateMetadata(): Promise<Metadata> {
         title,
         description,
         alternates: {
-            canonical: `${site_url}/compare/AFFiNE-vs-appflowy`,
+            canonical: `${site_url}/compare/appflowy-vs-affine`,
         },
         robots: {
             index: true,
@@ -102,10 +102,10 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: `${site_url}/compare/AFFiNE-vs-appflowy`,
+            url: `${site_url}/compare/appflowy-vs-affine`,
             type: 'article',
             siteName: 'AppFlowy',
-            publishedTime: new Date().toISOString(),
+            publishedTime: '2026-07-16T00:00:00Z',
             modifiedTime: new Date().toISOString(),
             images: [
                 {
@@ -125,6 +125,7 @@ export async function generateMetadata(): Promise<Metadata> {
         keywords: [
             'appflowy vs AFFiNE',
             'AFFiNE comparison',
+            'comparing AFFiNE and AppFlowy',
             'best self-hosted Notion alternative',
             'self-hosted productivity app',
             'AFFiNE review',
@@ -147,7 +148,7 @@ function generateListSchema() {
         '@type': ['WebPage', 'ItemPage'],
         name: title,
         description: description,
-        url: `${site_url}/compare/AFFiNE-vs-appflowy`,
+        url: `${site_url}/compare/appflowy-vs-affine`,
         mainEntity: {
             '@type': 'ItemList',
             itemListElement: [

--- a/app/compare/appflowy-vs-docmost/page.tsx
+++ b/app/compare/appflowy-vs-docmost/page.tsx
@@ -127,7 +127,7 @@ export async function generateMetadata(): Promise<Metadata> {
             url: `${site_url}/compare/appflowy-vs-docmost`,
             type: 'article',
             siteName: 'AppFlowy',
-            publishedTime: '2024-10-14T00:00:00Z',
+            publishedTime: '2026-07-16T00:00:00Z',
             modifiedTime: new Date().toISOString(),
             images: [
                 {

--- a/app/compare/appflowy-vs-outline/page.tsx
+++ b/app/compare/appflowy-vs-outline/page.tsx
@@ -108,7 +108,7 @@ export async function generateMetadata(): Promise<Metadata> {
             url: `${site_url}/compare/appflowy-vs-outline`,
             type: 'article',
             siteName: 'AppFlowy',
-            publishedTime: '2024-10-14T00:00:00Z',
+            publishedTime: '2026-07-02T00:00:00Z',
             modifiedTime: new Date().toISOString(),
             images: [
                 {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,147 +3,147 @@
 
      <url>
         <loc>https://appflowy.com/</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/about</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/appflowy-blocks</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/compare/notion-vs-appflowy</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/compare/appflowy-vs-affine</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/compare/appflowy-vs-docmost</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/compare/appflowy-vs-outline</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/contact</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/contributors</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/download</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/downloaded</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/invitation/expired</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/join</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/pricing</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/privacy</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/subscribe-newsletter</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/templates</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/templates/[category_name]</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/templates/[category_name]/[id]</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/terms</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
 
     <url>
         <loc>https://appflowy.com/what-is-new</loc>
-        <lastmod>2026-07-17T04:21:21.666Z</lastmod>
+        <lastmod>2026-07-24T04:21:21.666Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->
Fixes the incorrect URL. Since the page is hosted on appflowy/compare/appflowy-vs-affine, the url during metadata generation should also be the same and not /affine-vs-appflowy as is the case as of now. 
<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
